### PR TITLE
Expand user abbreviations without using $fish_user_abbreviations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
     - sudo apt-get -y install fish
 script:
     - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisher
-    - fish -c "fisher fishtape .; fishtape test/gabbr.fish"
+    - fish -c "fisher add jorgebucaran/fishtape; fishtape test/gabbr.fish"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_install:
     - sudo apt-get -y install fish
 script:
     - curl -Lo ~/.config/fish/functions/fisher.fish --create-dirs git.io/fisher
-    - fish -c "fisher add jorgebucaran/fishtape; fishtape test/gabbr.fish"
+    - fish -c "fisher add jorgebucaran/fishtape; fishtape functions/gabbr.fish test/gabbr.fish"

--- a/functions/__gabbr_expand.fish
+++ b/functions/__gabbr_expand.fish
@@ -6,10 +6,11 @@ function __gabbr_expand
 
     # expand abbreviations
     if test 0 = (count (commandline -poc))
-        for abbr in $fish_user_abbreviations
-            echo $abbr | read word phrase
+        for word in (abbr -l)
             if test "$word" = (commandline -t)
-                commandline -t $phrase
+                set escaped_word (string escape --style=var -- $word)
+                set phrase "_fish_abbr_$escaped_word"
+                commandline -t $$phrase
             end
         end
     end


### PR DESCRIPTION
Happy New Year!

I love fish-shell and gabbr 😃❤️
Thank you for developing nice plug-in!

Unfortunately, in [fish 3.0.0](https://github.com/fish-shell/fish-shell/releases/tag/3.0.0), gabbr doesn't expand user abbreviations because `fish_user_abbreviations` is deprecated.
This PR fixes it.

----

The idea of this implementation came from the original abbr function.
https://github.com/fish-shell/fish-shell/blob/master/share/functions/abbr.fish#L175-L201

In `man abbr`:
```
Internals
    Each abbreviation is stored in its own global or universal variable. The name consists of the prefix _fish_abbr_ followed by the WORD after being transformed by string escape style=var. The WORD cannot
    contain a space but all other characters are legal.
```

So it builds `_fish_abbr_*` var and fetches the phrase definition by using $ dereference.
Example:

```
$ abbr -s
abbr -a -U -- gco 'git checkout'

$ set word 'gco'
$ set phrase "_fish_abbr_$word"
$ echo $$phrase
git checkout
```

Note that if the abbr definition contains character like `!`, it will be escaped in var name.
This is why it does `string escape --style=var -- $word` in L11.