### PR TITLE
Fix/reload option

### DIFF
--- a/functions/gabbr.fish
+++ b/functions/gabbr.fish
@@ -136,6 +136,10 @@ Options:
 
         case -r --reload
             if set -q gabbr_config
+                # use a universal variable as default
+                if not set -q global_abbreviations
+                    set -U global_abbreviations
+                end
                 set global_abbreviations
 
                 for abbr in (cat $gabbr_config)
@@ -149,7 +153,7 @@ Options:
     function gabbr.export
         if set -q gabbr_config
             if not touch $gabbr_config ^/dev/null
-                echo "gabbr: `\$gabbr_config` is invalid"  >&2
+                echo "gabbr: `\$gabbr_config` is invalid" >&2
                 return 1
             end
             echo -n '' >$gabbr_config

--- a/test/gabbr.fish
+++ b/test/gabbr.fish
@@ -2,63 +2,52 @@ function setup
     set -g global_abbreviations
 end
 
-test "add an abbreviation"
-    "G" = (
+@test "add an abbreviation" (
+    gabbr --add G '| grep'
+    gabbr --list
+) = "G"
+
+@test "count abbreviations" (
+    count (
         gabbr --add G '| grep'
         gabbr --list
-        )
-end
+    )
+) -eq 1
 
-test "count abbreviations"
-    1 = (count (
-        gabbr --add G '| grep'
-        gabbr --list
-        ))
-end
-
-test "erase an abbreviation"
-    0 = (count (
+@test "erase an abbreviation" (
+    count (
         gabbr --add G '| grep'
         gabbr --erase G
         gabbr --list
-        ))
-end
+    )
+) -eq 0
 
-test "show abbreviations"
-    "gabbr G '| grep'" "gabbr L '| less'" = (
-        gabbr --add G '| grep'
-        gabbr --add L '| less'
-        gabbr --show
-        )
-end
+@test "show abbreviations" (
+    gabbr --add G '| grep'
+    gabbr --add L '| less'
+    gabbr --show
+) = "gabbr G '| grep'" "gabbr L '| less'"
 
-test "list abbreviations"
-    G L = (
-        gabbr --add G '| grep'
-        gabbr --add L '| less'
-        gabbr --list
-        )
-end
+@test "list abbreviations" (
+    gabbr --add G '| grep'
+    gabbr --add L '| less'
+    gabbr --list
+) = G L
 
-test "add function abbreviations"
-    "gabbr E -f 'echo expanded'" = (
-        gabbr --function E 'echo expanded'
-        gabbr --show
-        )
-end
+@test "add function abbreviations" (
+    gabbr --function E 'echo expanded'
+    gabbr --show
+) = "gabbr E -f 'echo expanded'"
 
-test "reload abbereviations"
-    G = (set -g gabbr_config (dirname (realpath $FILENAME))"/.gabbr.config"
-        echo "G | grep" > "$gabbr_config"
-        gabbr --reload
-        gabbr --list
-        rm "$gabbr_config"
-        )
-end
+@test "reload abbereviations" (
+    set -g gabbr_config (dirname (realpath $current_filename))"/.gabbr.config"
+    echo "G | grep" > "$gabbr_config"
+    gabbr --reload
+    gabbr --list
+    rm "$gabbr_config"
+) = G
 
-test "add suffix alias"
-    "gabbr py -x python" = (
-        gabbr --suffix py python
-        gabbr --show
-        )
-end
+@test "add suffix alias" (
+    gabbr --suffix py python
+    gabbr --show
+) = "gabbr py -x python"

--- a/test/gabbr.fish
+++ b/test/gabbr.fish
@@ -40,12 +40,21 @@ end
 ) = "gabbr E -f 'echo expanded'"
 
 @test "reload abbereviations" (
-    set -g gabbr_config (dirname (realpath $current_filename))"/.gabbr.config"
+    set -g gabbr_config $current_dirname/.gabbr.config
     echo "G | grep" > "$gabbr_config"
     gabbr --reload
     gabbr --list
     rm "$gabbr_config"
 ) = G
+
+@test 'reload abbereviations when $global_abbreviations is not set' (
+    unset global_abbreviations
+    set -g gabbr_config $current_dirname/.gabbr.config
+    echo "F | fzf" > "$gabbr_config"
+    fish -c "set -g gabbr_config $gabbr_config && gabbr --reload"
+    gabbr --list
+    rm "$gabbr_config"
+) = F
 
 @test "add suffix alias" (
     gabbr --suffix py python


### PR DESCRIPTION
Unfortunately, `gabbr -r` command failed if not set `global_abbreviations` variable in advance.
This PR fixes it.

You can check `gabbr -r` failure in the following steps:
1. `unset global_abbreviations`
2. `gabbr -r`
3. `gabbr -l` returns empty response...